### PR TITLE
Turn restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Pydermonkey needs to build spidermonkey-1.8.1pre, and the URL is out of date. To
  * run `python setup.py build_spidermonkey`
  * go back to the virtualenv root and run `pip install --no-download pydermonkey`
  
-Install
--------
+Installing the app
+------------------
 
  * make a settings_site.py file and add overrides for things like:
    * `DATABASES`
@@ -57,9 +57,21 @@ Load data
  * run `manage.py loaddata v16_layers` to populate the layer models.
  * run `manage.py loaddata example_tags` to load some example tags for road_cl,
    and some defaults for all layers.
- * 
+
+OR, to clone an existing installation
+
+ * go to that existing installation (e.g. http://linz2osm.openstreetmap.org.nz), click
+   on "Layers", then click "Export layers and tags".
+ * download the file, and put it on your new machine
+ * on your new machine, run `manage.py loaddata <path_to_your_downloaded_file>`
+
+Then, either way:
 
  * run `manage.py generate_datasets` to configure the app for the datasets and layers you've added
+
+Running in development mode
+---------------------------
+
  * run `manage.py runserver`
  * from the linz2osm dir, run `../manage.py celery worker`
  * head to http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -77,14 +77,16 @@ Running in development mode
  * head to http://localhost:8000
  * have fun! :)
 
-New Datasets
-------------
+New Datasets and Layers
+-----------------------
 
 To load some other IFF data, use the linz_topo scripts from nz-geodata-scripts
 to populate a PostGIS DB. Then, add it as a database in the settings file,
-(make sure it has _description and _srid defined) and it should just work.
+(make sure it has _description and _srid defined).
 
  * http://code.google.com/p/nz-geodata-scripts/wiki/LinzTopo   
+
+Whenever you add a new dataset or layer, run `manage.py generate_datasets` to update the app.
 
 Support, Bugs, Ideas
 --------------------

--- a/linz2osm/convert/osm.py
+++ b/linz2osm/convert/osm.py
@@ -447,7 +447,7 @@ def export_custom(layer_in_dataset, feature_ids = None, workslice_id = None):
             elif m_layer.geometry_type == 'LINESTRING':
                 osm_feature_type = 'way'
             else:
-                raise ValueError("We do not yet support %ss as members" % m_layer.geometry_type)
+                raise NotImplementedError("We do not yet support %ss as members" % m_layer.geometry_type)
             key = (db_table_name, db_feature_id)
             # Reuse a member feature if already included as a different role.
             if key not in member_feature_map:
@@ -657,7 +657,6 @@ class OSMCreateWriter(OSMWriter):
     def build_way(self, coords, tags, tag_nodes_at_ends=False, first_node_ref=None, last_node_ref=None):
         ids = []
         rem_coords = [(wrap_longitude(x), y) for (x, y) in coords]
-        node_map = {}
         special_node_type = "first" if tag_nodes_at_ends else None
         while True:
             w = ElementTree.Element('way', id=self.next_id)
@@ -665,7 +664,6 @@ class OSMCreateWriter(OSMWriter):
             cur_coords, rem_coords = coords_for_next_way(rem_coords, self.WAY_SPLIT_SIZE)
 
             cur_coords_last_idx = len(cur_coords) - 1
-            last_coords = None
             for i,c in enumerate(cur_coords):
                 # Handle tagging special node types
                 if tag_nodes_at_ends and not rem_coords:
@@ -690,7 +688,6 @@ class OSMCreateWriter(OSMWriter):
 
                 # Actually generate some XML now
                 ElementTree.SubElement(w, 'nd', ref=n_id)
-                last_coords = c
             self.build_tags(w, tags, "geometry")
             self.n_create.append(w)
             ids.append(w.get('id'))

--- a/linz2osm/data_dict/admin.py
+++ b/linz2osm/data_dict/admin.py
@@ -61,9 +61,6 @@ class TagInlineForm(forms.ModelForm):
     class Meta:
         model = Tag
 
-    # def __init__(self, *args, **kwargs):
-    #     super(TagInlineForm, self).__init__(*args, **kwargs)
-
     def clean_code(self):
         code_text = self.cleaned_data['code']
 

--- a/linz2osm/data_dict/admin.py
+++ b/linz2osm/data_dict/admin.py
@@ -21,7 +21,7 @@ from django.template.loader import render_to_string
 from django import forms
 import pydermonkey
 
-from linz2osm.data_dict.models import Layer, Tag, LayerInDataset, Dataset, Group
+from linz2osm.data_dict.models import Layer, Tag, LayerInDataset, Dataset, Group, Member
 
 class LayerInDatasetInline(admin.StackedInline):
     model = LayerInDataset
@@ -61,8 +61,8 @@ class TagInlineForm(forms.ModelForm):
     class Meta:
         model = Tag
 
-    def __init__(self, *args, **kwargs):
-        super(TagInlineForm, self).__init__(*args, **kwargs)
+    # def __init__(self, *args, **kwargs):
+    #     super(TagInlineForm, self).__init__(*args, **kwargs)
 
     def clean_code(self):
         code_text = self.cleaned_data['code']
@@ -83,6 +83,18 @@ class TagInline(admin.StackedInline):
     verbose_name = 'Tag'
     verbose_name_plural = 'Tags'
     form = TagInlineForm
+
+class MemberInlineForm(forms.ModelForm):
+    class Meta:
+        model = Member
+
+class LayerMemberInline(admin.StackedInline):
+    model = Member
+    fk_name = 'member_layer'
+    extra = 1
+    verbose_name = 'Member'
+    verbose_name_plural = 'Members'
+    form = MemberInlineForm
 
 class GroupTagInline(TagInline):
     exclude = ("layer",)
@@ -176,6 +188,7 @@ class LayerAdmin(admin.ModelAdmin):
     inlines = [
         LayerInDatasetInline,
         LayerTagInline,
+        LayerMemberInline
     ]
     ordering = ('name', 'group',)
     readonly_fields = ('special_node_reuse_logic',)

--- a/linz2osm/data_dict/admin.py
+++ b/linz2osm/data_dict/admin.py
@@ -188,7 +188,7 @@ class LayerAdmin(admin.ModelAdmin):
         LayerMemberInline
     ]
     ordering = ('name', 'group',)
-    readonly_fields = ('special_node_reuse_logic',)
+    readonly_fields = ('special_node_reuse_logic', 'special_way_reuse_logic')
     search_fields = ('name', 'notes',)
     save_on_top = True
 

--- a/linz2osm/data_dict/admin.py
+++ b/linz2osm/data_dict/admin.py
@@ -90,7 +90,7 @@ class MemberInlineForm(forms.ModelForm):
 
 class LayerMemberInline(admin.StackedInline):
     model = Member
-    fk_name = 'member_layer'
+    fk_name = 'relation_layer'
     extra = 1
     verbose_name = 'Member'
     verbose_name_plural = 'Members'

--- a/linz2osm/data_dict/migrations/0028_auto__add_member__add_unique_member_relation_layer_member_layer_role.py
+++ b/linz2osm/data_dict/migrations/0028_auto__add_member__add_unique_member_relation_layer_member_layer_role.py
@@ -13,9 +13,8 @@ class Migration(SchemaMigration):
             (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
             ('relation_layer', self.gf('django.db.models.fields.related.ForeignKey')(related_name='members', to=orm['data_dict.Layer'])),
             ('member_layer', self.gf('django.db.models.fields.related.ForeignKey')(related_name='memberships', to=orm['data_dict.Layer'])),
-            ('relation_lookup_field', self.gf('django.db.models.fields.CharField')(max_length=255)),
-            ('member_lookup_field', self.gf('django.db.models.fields.CharField')(max_length=255)),
             ('role', self.gf('django.db.models.fields.CharField')(max_length=100)),
+            ('join_condition', self.gf('django.db.models.fields.TextField')()),
         ))
         db.send_create_signal(u'data_dict', ['Member'])
 
@@ -129,10 +128,9 @@ class Migration(SchemaMigration):
         u'data_dict.member': {
             'Meta': {'unique_together': "(('relation_layer', 'member_layer', 'role'),)", 'object_name': 'Member'},
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'join_condition': ('django.db.models.fields.TextField', [], {}),
             'member_layer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'memberships'", 'to': u"orm['data_dict.Layer']"}),
-            'member_lookup_field': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
             'relation_layer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'members'", 'to': u"orm['data_dict.Layer']"}),
-            'relation_lookup_field': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
             'role': ('django.db.models.fields.CharField', [], {'max_length': '100'})
         },
         u'data_dict.tag': {

--- a/linz2osm/data_dict/migrations/0028_auto__add_member__add_unique_member_relation_layer_member_layer_role.py
+++ b/linz2osm/data_dict/migrations/0028_auto__add_member__add_unique_member_relation_layer_member_layer_role.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Member'
+        db.create_table(u'data_dict_member', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('relation_layer', self.gf('django.db.models.fields.related.ForeignKey')(related_name='members', to=orm['data_dict.Layer'])),
+            ('member_layer', self.gf('django.db.models.fields.related.ForeignKey')(related_name='memberships', to=orm['data_dict.Layer'])),
+            ('relation_lookup_field', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('member_lookup_field', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('role', self.gf('django.db.models.fields.CharField')(max_length=100)),
+        ))
+        db.send_create_signal(u'data_dict', ['Member'])
+
+        # Adding unique constraint on 'Member', fields ['relation_layer', 'member_layer', 'role']
+        db.create_unique(u'data_dict_member', ['relation_layer_id', 'member_layer_id', 'role'])
+
+
+    def backwards(self, orm):
+        # Removing unique constraint on 'Member', fields ['relation_layer', 'member_layer', 'role']
+        db.delete_unique(u'data_dict_member', ['relation_layer_id', 'member_layer_id', 'role'])
+
+        # Deleting model 'Member'
+        db.delete_table(u'data_dict_member')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'data_dict.dataset': {
+            'Meta': {'object_name': 'Dataset'},
+            'database_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'generating_deletions_osm': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Group']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255', 'primary_key': 'True'}),
+            'srid': ('django.db.models.fields.IntegerField', [], {}),
+            'update_method': ('django.db.models.fields.CharField', [], {'default': "'manual'", 'max_length': '255'}),
+            'version': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'data_dict.datasetupdate': {
+            'Meta': {'object_name': 'DatasetUpdate'},
+            'complete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'dataset': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Dataset']"}),
+            'error': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'from_version': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'seq': ('django.db.models.fields.IntegerField', [], {}),
+            'to_version': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'data_dict.group': {
+            'Meta': {'object_name': 'Group'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255', 'primary_key': 'True'})
+        },
+        u'data_dict.layer': {
+            'Meta': {'object_name': 'Layer'},
+            'datasets': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['data_dict.Dataset']", 'through': u"orm['data_dict.LayerInDataset']", 'symmetrical': 'False'}),
+            'entity': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '200', 'blank': 'True'}),
+            'geometry_type': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Group']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'primary_key': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'pkey_name': ('django.db.models.fields.CharField', [], {'default': "'ogc_fid'", 'max_length': '255'}),
+            'processors': ('linz2osm.utils.db_fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'special_dataset_name_tag': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_dataset_version_tag': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_end_node_field_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_node_reuse_logic': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'special_node_tag_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_start_node_field_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'tags_ql': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'wfs_cql_filter': ('django.db.models.fields.TextField', [], {'max_length': '255', 'blank': 'True'}),
+            'wfs_type_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'data_dict.layerindataset': {
+            'Meta': {'object_name': 'LayerInDataset'},
+            'completed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'dataset': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Dataset']"}),
+            'extent': ('django.contrib.gis.db.models.fields.GeometryField', [], {'null': 'True'}),
+            'features_total': ('django.db.models.fields.IntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_deletions_dump_filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'layer': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Layer']"}),
+            'tagging_approved': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'data_dict.member': {
+            'Meta': {'unique_together': "(('relation_layer', 'member_layer', 'role'),)", 'object_name': 'Member'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'member_layer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'memberships'", 'to': u"orm['data_dict.Layer']"}),
+            'member_lookup_field': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'relation_layer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'members'", 'to': u"orm['data_dict.Layer']"}),
+            'relation_lookup_field': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'role': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'data_dict.tag': {
+            'Meta': {'unique_together': "(('layer', 'apply_to', 'tag'),)", 'object_name': 'Tag'},
+            'apply_to': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'code': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'conflict_search_tag': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'tags'", 'null': 'True', 'to': u"orm['data_dict.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'layer': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'tags'", 'null': 'True', 'to': u"orm['data_dict.Layer']"}),
+            'match_search_tag': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'tag': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['data_dict']

--- a/linz2osm/data_dict/migrations/0029_auto__add_field_layer_special_way_reuse_logic.py
+++ b/linz2osm/data_dict/migrations/0029_auto__add_field_layer_special_way_reuse_logic.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Layer.special_way_reuse_logic'
+        db.add_column(u'data_dict_layer', 'special_way_reuse_logic',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Layer.special_way_reuse_logic'
+        db.delete_column(u'data_dict_layer', 'special_way_reuse_logic')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'data_dict.dataset': {
+            'Meta': {'object_name': 'Dataset'},
+            'database_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'generating_deletions_osm': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Group']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255', 'primary_key': 'True'}),
+            'srid': ('django.db.models.fields.IntegerField', [], {}),
+            'update_method': ('django.db.models.fields.CharField', [], {'default': "'manual'", 'max_length': '255'}),
+            'version': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'data_dict.datasetupdate': {
+            'Meta': {'object_name': 'DatasetUpdate'},
+            'complete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'dataset': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Dataset']"}),
+            'error': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'from_version': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'seq': ('django.db.models.fields.IntegerField', [], {}),
+            'to_version': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'data_dict.group': {
+            'Meta': {'object_name': 'Group'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255', 'primary_key': 'True'})
+        },
+        u'data_dict.layer': {
+            'Meta': {'object_name': 'Layer'},
+            'datasets': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['data_dict.Dataset']", 'through': u"orm['data_dict.LayerInDataset']", 'symmetrical': 'False'}),
+            'entity': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '200', 'blank': 'True'}),
+            'geometry_type': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Group']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'primary_key': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'pkey_name': ('django.db.models.fields.CharField', [], {'default': "'ogc_fid'", 'max_length': '255'}),
+            'processors': ('linz2osm.utils.db_fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'special_dataset_name_tag': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_dataset_version_tag': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_end_node_field_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_node_reuse_logic': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'special_node_tag_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_start_node_field_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_way_reuse_logic': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'tags_ql': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'wfs_cql_filter': ('django.db.models.fields.TextField', [], {'max_length': '255', 'blank': 'True'}),
+            'wfs_type_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'data_dict.layerindataset': {
+            'Meta': {'object_name': 'LayerInDataset'},
+            'completed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'dataset': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Dataset']"}),
+            'extent': ('django.contrib.gis.db.models.fields.GeometryField', [], {'null': 'True'}),
+            'features_total': ('django.db.models.fields.IntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_deletions_dump_filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'layer': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Layer']"}),
+            'tagging_approved': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'data_dict.member': {
+            'Meta': {'unique_together': "(('relation_layer', 'member_layer', 'role'),)", 'object_name': 'Member'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'join_condition': ('django.db.models.fields.TextField', [], {}),
+            'member_layer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'memberships'", 'to': u"orm['data_dict.Layer']"}),
+            'relation_layer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'members'", 'to': u"orm['data_dict.Layer']"}),
+            'role': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'data_dict.tag': {
+            'Meta': {'unique_together': "(('layer', 'apply_to', 'tag'),)", 'object_name': 'Tag'},
+            'apply_to': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'code': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'conflict_search_tag': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'tags'", 'null': 'True', 'to': u"orm['data_dict.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'layer': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'tags'", 'null': 'True', 'to': u"orm['data_dict.Layer']"}),
+            'match_search_tag': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'tag': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['data_dict']

--- a/linz2osm/data_dict/migrations/0030_auto__add_field_layer_special_way_field_name__add_field_layer_special_.py
+++ b/linz2osm/data_dict/migrations/0030_auto__add_field_layer_special_way_field_name__add_field_layer_special_.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Layer.special_way_field_name'
+        db.add_column(u'data_dict_layer', 'special_way_field_name',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=255, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Layer.special_way_tag_name'
+        db.add_column(u'data_dict_layer', 'special_way_tag_name',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=255, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Layer.special_way_field_name'
+        db.delete_column(u'data_dict_layer', 'special_way_field_name')
+
+        # Deleting field 'Layer.special_way_tag_name'
+        db.delete_column(u'data_dict_layer', 'special_way_tag_name')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'data_dict.dataset': {
+            'Meta': {'object_name': 'Dataset'},
+            'database_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'generating_deletions_osm': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Group']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255', 'primary_key': 'True'}),
+            'srid': ('django.db.models.fields.IntegerField', [], {}),
+            'update_method': ('django.db.models.fields.CharField', [], {'default': "'manual'", 'max_length': '255'}),
+            'version': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'data_dict.datasetupdate': {
+            'Meta': {'object_name': 'DatasetUpdate'},
+            'complete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'dataset': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Dataset']"}),
+            'error': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'from_version': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'seq': ('django.db.models.fields.IntegerField', [], {}),
+            'to_version': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'data_dict.group': {
+            'Meta': {'object_name': 'Group'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255', 'primary_key': 'True'})
+        },
+        u'data_dict.layer': {
+            'Meta': {'object_name': 'Layer'},
+            'datasets': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['data_dict.Dataset']", 'through': u"orm['data_dict.LayerInDataset']", 'symmetrical': 'False'}),
+            'entity': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '200', 'blank': 'True'}),
+            'geometry_type': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Group']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'primary_key': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'pkey_name': ('django.db.models.fields.CharField', [], {'default': "'ogc_fid'", 'max_length': '255'}),
+            'processors': ('linz2osm.utils.db_fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'special_dataset_name_tag': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_dataset_version_tag': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_end_node_field_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_node_reuse_logic': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'special_node_tag_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_start_node_field_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_way_field_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_way_reuse_logic': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'special_way_tag_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'tags_ql': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'wfs_cql_filter': ('django.db.models.fields.TextField', [], {'max_length': '255', 'blank': 'True'}),
+            'wfs_type_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'data_dict.layerindataset': {
+            'Meta': {'object_name': 'LayerInDataset'},
+            'completed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'dataset': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Dataset']"}),
+            'extent': ('django.contrib.gis.db.models.fields.GeometryField', [], {'null': 'True'}),
+            'features_total': ('django.db.models.fields.IntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_deletions_dump_filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'layer': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Layer']"}),
+            'tagging_approved': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'data_dict.member': {
+            'Meta': {'unique_together': "(('relation_layer', 'member_layer', 'role'),)", 'object_name': 'Member'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'join_condition': ('django.db.models.fields.TextField', [], {}),
+            'member_layer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'memberships'", 'to': u"orm['data_dict.Layer']"}),
+            'relation_layer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'members'", 'to': u"orm['data_dict.Layer']"}),
+            'role': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'data_dict.tag': {
+            'Meta': {'unique_together': "(('layer', 'apply_to', 'tag'),)", 'object_name': 'Tag'},
+            'apply_to': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'code': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'conflict_search_tag': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'tags'", 'null': 'True', 'to': u"orm['data_dict.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'layer': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'tags'", 'null': 'True', 'to': u"orm['data_dict.Layer']"}),
+            'match_search_tag': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'tag': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['data_dict']

--- a/linz2osm/data_dict/models.py
+++ b/linz2osm/data_dict/models.py
@@ -226,6 +226,10 @@ class Layer(models.Model):
 
     @property
     def feature_limit(self):
+        # These are limits on the number of elements you can check out at once,
+        # so that progress on layers isn't delayed with very long-running merges.
+        # They are almost completely arbitrary, but designed to make sure that
+        # a workslice shouldn't be more than a hour's work.
         if self.geometry_type == 'POINT':
             return 1000
         elif self.geometry_type == 'LINESTRING':

--- a/linz2osm/data_dict/models.py
+++ b/linz2osm/data_dict/models.py
@@ -25,7 +25,6 @@ from functools import total_ordering
 
 from django.db import models, connections, transaction
 from django.db.models import Sum
-from django.utils import text
 from django.conf import settings
 from django.contrib.gis.db import models as geomodels
 from django.contrib.gis import geos

--- a/linz2osm/data_dict/models.py
+++ b/linz2osm/data_dict/models.py
@@ -53,6 +53,13 @@ class DatasetManager(models.Manager):
             if name != 'default':
                 if Dataset.objects.filter(name=name).exists():
                     dataset = Dataset.objects.get(name=name)
+                    dataset.database_name = details['NAME']
+                    dataset.description = details['_description']
+                    dataset.version = details['_version']
+                    new_srid = int(details["_srid"])
+                    if dataset.srid != new_srid:
+                        raise ValueError("Dataset already exists with a different SRID (cannot update %d to %d)!" % (dataset.srid, new_srid))
+                    dataset.save()
                 else:
                     dataset = self.create(name = name,
                                           database_name = details['NAME'],

--- a/linz2osm/data_dict/models.py
+++ b/linz2osm/data_dict/models.py
@@ -197,10 +197,16 @@ class Layer(models.Model):
     pkey_name = models.CharField(max_length=255, default='ogc_fid', choices=PKEY_CHOICES, help_text='Changing this on an existing dataset requires an update to existing workslice features in database')
     tags_ql = models.TextField(blank=True, null=True, help_text=('What tags to include in the OSM search. Separated with whitespace. In OSM Overpass API format ["name"="value"] ["name"~"valueish"] ["name"="this|that"] ["name"!="not-this"] etc.'), verbose_name='tags for overpass QL')
     # FIXME: do this with a flag on the relevant tags?
+    # You really don't want to use these unless you know what you're doing.
+    # They are intended for a carefully interlinked set of mp_node, mp_restrict and mp_segment_highway
+    # from NZOpenGPS data.
     special_node_reuse_logic = models.BooleanField(default=False)
-    special_start_node_field_name = models.CharField(max_length=255, blank=True, editable=False)
-    special_end_node_field_name = models.CharField(max_length=255, blank=True, editable=False)
+    special_way_reuse_logic = models.BooleanField(default=False)
+    special_start_node_field_name = models.CharField(max_length=255, blank=True, editable=False, help_text='For special node/way reuse logic: the field name for the first node (ways) or only node (points)')
+    special_end_node_field_name = models.CharField(max_length=255, blank=True, editable=False, help_text='For special node/way reuse logic: the field name for the last node (ways only)')
     special_node_tag_name = models.CharField(max_length=255, blank=True, editable=False)
+    special_way_field_name = models.CharField(max_length=255, blank=True, editable=False)
+    special_way_tag_name = models.CharField(max_length=255, blank=True, editable=False)
     special_dataset_name_tag = models.CharField(max_length=255, blank=True, editable=False)
     special_dataset_version_tag = models.CharField(max_length=255, blank=True, editable=False)
     wfs_type_name = models.CharField(max_length=255, blank=True, verbose_name='WFS typeName', help_text='Used for LDS or WFS updates')

--- a/linz2osm/data_dict/templates/data_dict/show_tagging.html
+++ b/linz2osm/data_dict/templates/data_dict/show_tagging.html
@@ -76,7 +76,12 @@
 </div>
 {% for member in layer.members.all %}
 <div class="span8 code-content">
-  <strong><code>{{member.role}}</code></strong> &mdash; <strong><code>{{member.member_layer_id}}</code></strong>
+  <strong><code>{{member.role}}</code></strong> &mdash; 
+  <strong><code>
+    <a href="{% url 'linz2osm.data_dict.views.show_tagging' layer_id=member.member_layer %}">
+      {{member.member_layer_id}}
+    </a>
+  </code></strong>
   {{ member.join_condition|stylize_no_ln:"sql" }}
 </div>
 {% endfor %}

--- a/linz2osm/data_dict/templates/data_dict/show_tagging.html
+++ b/linz2osm/data_dict/templates/data_dict/show_tagging.html
@@ -65,4 +65,18 @@
 {% endfor %}
 
 {% endfor %}
+
+{% if layer.geometry_type == 'RELATION' %}
+<div class="row">
+  <div class="span12">
+    <h3>Members</h3>
+  </div>
+</div>
+{% for member in layer.members.all %}
+<div class="span8 code-content">
+  <strong><code>{{member.role}}</code></strong> &mdash; <strong><code>{{member.member_layer_id}}</code></strong>
+  {{ member.join_condition|stylize_no_ln:"sql" }}
+</div>
+{% endfor %}
+{% endif %}
 {% endblock %}

--- a/linz2osm/data_dict/templates/data_dict/show_tagging.html
+++ b/linz2osm/data_dict/templates/data_dict/show_tagging.html
@@ -49,6 +49,7 @@
 
 {% for group_title, tags in grouped_tags %}
 <div class="row"></div>
+{% if tags %}
 <div class="row">
   <div class="span12">
     <h4>{{ group_title }}</h4>
@@ -63,10 +64,11 @@
   {% endif %}
 </div>
 {% endfor %}
-
+{% endif %}
 {% endfor %}
 
 {% if layer.geometry_type == 'RELATION' %}
+<div class="row"></div>
 <div class="row">
   <div class="span12">
     <h3>Members</h3>

--- a/linz2osm/data_dict/views.py
+++ b/linz2osm/data_dict/views.py
@@ -245,7 +245,8 @@ def export_data_dict(request):
             "xml", chain(
                 Group.objects.order_by('name').all(),
                 Layer.objects.order_by('name').all(),
-                Tag.objects.order_by('layer', 'tag').all()),
+                Tag.objects.order_by('layer', 'tag').all(),
+                Member.objects.order_by('relation_layer', 'member_layer', 'role').all()),
             indent=4,
             content_type='application/xml'))
     response['Content-Type'] = "application/xml"

--- a/linz2osm/utils/db_fields.py
+++ b/linz2osm/utils/db_fields.py
@@ -52,13 +52,6 @@ class JSONDateEncoder(json.JSONEncoder):
             return obj.strftime('%H:%M:%S')
         return json.JSONEncoder.default(self, obj)
 
-# class JSONField(models.TextField):
-#     description = _("Data that serializes and deserializes into and out of JSON.")
-
-#     def pre_save(self, model_instance, add):
-#         value = getattr(model_instance, self.attname, None)
-#         return self._dumps(value)
-
 
 # Based on http://www.djangosnippets.org/snippets/1478/
 @register_south_field

--- a/linz2osm/workslices/migrations/0007_auto__add_field_workslice_version.py
+++ b/linz2osm/workslices/migrations/0007_auto__add_field_workslice_version.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Workslice.version'
+        db.add_column(u'workslices_workslice', 'version',
+                      self.gf('django.db.models.fields.TextField')(default='', blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Workslice.version'
+        db.delete_column(u'workslices_workslice', 'version')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'data_dict.dataset': {
+            'Meta': {'object_name': 'Dataset'},
+            'database_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'generating_deletions_osm': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Group']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255', 'primary_key': 'True'}),
+            'srid': ('django.db.models.fields.IntegerField', [], {}),
+            'update_method': ('django.db.models.fields.CharField', [], {'default': "'manual'", 'max_length': '255'}),
+            'version': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'data_dict.group': {
+            'Meta': {'object_name': 'Group'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255', 'primary_key': 'True'})
+        },
+        u'data_dict.layer': {
+            'Meta': {'object_name': 'Layer'},
+            'datasets': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['data_dict.Dataset']", 'through': u"orm['data_dict.LayerInDataset']", 'symmetrical': 'False'}),
+            'entity': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '200', 'blank': 'True'}),
+            'geometry_type': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Group']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'primary_key': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'pkey_name': ('django.db.models.fields.CharField', [], {'default': "'ogc_fid'", 'max_length': '255'}),
+            'processors': ('linz2osm.utils.db_fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'special_dataset_name_tag': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_dataset_version_tag': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_end_node_field_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_node_reuse_logic': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'special_node_tag_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_start_node_field_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'tags_ql': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'wfs_cql_filter': ('django.db.models.fields.TextField', [], {'max_length': '255', 'blank': 'True'}),
+            'wfs_type_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'data_dict.layerindataset': {
+            'Meta': {'object_name': 'LayerInDataset'},
+            'completed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'dataset': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Dataset']"}),
+            'extent': ('django.contrib.gis.db.models.fields.GeometryField', [], {'null': 'True'}),
+            'features_total': ('django.db.models.fields.IntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_deletions_dump_filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'layer': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Layer']"}),
+            'tagging_approved': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'workslices.workslice': {
+            'Meta': {'object_name': 'Workslice'},
+            'checked_out_at': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'checkout_extent': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {}),
+            'feature_count': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'file_size': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'followup_deadline': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'layer_in_dataset': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.LayerInDataset']"}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'status_changed_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'version': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'workslices.workslicefeature': {
+            'Meta': {'object_name': 'WorksliceFeature'},
+            'dirty': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'feature_id': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'layer_in_dataset': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.LayerInDataset']"}),
+            'workslice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['workslices.Workslice']"})
+        }
+    }
+
+    complete_apps = ['workslices']

--- a/linz2osm/workslices/migrations/0008_populate_workslice_versions.py
+++ b/linz2osm/workslices/migrations/0008_populate_workslice_versions.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        # Note: Don't use "from appname.models import ModelName".
+        # Use orm.ModelName to refer to models in this application,
+        # and orm['appname.ModelName'] for models in other applications.
+        for lid in orm['data_dict.LayerInDataset'].objects.all():
+            lid.workslice_set.update(version=lid.dataset.version)
+
+    def backwards(self, orm):
+        orm.Workslice.objects.update(version=None)
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'data_dict.dataset': {
+            'Meta': {'object_name': 'Dataset'},
+            'database_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'generating_deletions_osm': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Group']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255', 'primary_key': 'True'}),
+            'srid': ('django.db.models.fields.IntegerField', [], {}),
+            'update_method': ('django.db.models.fields.CharField', [], {'default': "'manual'", 'max_length': '255'}),
+            'version': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'data_dict.group': {
+            'Meta': {'object_name': 'Group'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255', 'primary_key': 'True'})
+        },
+        u'data_dict.layer': {
+            'Meta': {'object_name': 'Layer'},
+            'datasets': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['data_dict.Dataset']", 'through': u"orm['data_dict.LayerInDataset']", 'symmetrical': 'False'}),
+            'entity': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '200', 'blank': 'True'}),
+            'geometry_type': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Group']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'primary_key': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'pkey_name': ('django.db.models.fields.CharField', [], {'default': "'ogc_fid'", 'max_length': '255'}),
+            'processors': ('linz2osm.utils.db_fields.JSONField', [], {'null': 'True', 'blank': 'True'}),
+            'special_dataset_name_tag': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_dataset_version_tag': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_end_node_field_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_node_reuse_logic': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'special_node_tag_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'special_start_node_field_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'tags_ql': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'wfs_cql_filter': ('django.db.models.fields.TextField', [], {'max_length': '255', 'blank': 'True'}),
+            'wfs_type_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        u'data_dict.layerindataset': {
+            'Meta': {'object_name': 'LayerInDataset'},
+            'completed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'dataset': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Dataset']"}),
+            'extent': ('django.contrib.gis.db.models.fields.GeometryField', [], {'null': 'True'}),
+            'features_total': ('django.db.models.fields.IntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_deletions_dump_filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'layer': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.Layer']"}),
+            'tagging_approved': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'workslices.workslice': {
+            'Meta': {'object_name': 'Workslice'},
+            'checked_out_at': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'checkout_extent': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {}),
+            'feature_count': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'file_size': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'followup_deadline': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'layer_in_dataset': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.LayerInDataset']"}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'status_changed_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'version': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        u'workslices.workslicefeature': {
+            'Meta': {'object_name': 'WorksliceFeature'},
+            'dirty': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'feature_id': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'layer_in_dataset': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['data_dict.LayerInDataset']"}),
+            'workslice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['workslices.Workslice']"})
+        }
+    }
+
+    complete_apps = ['workslices']
+    symmetrical = True

--- a/linz2osm/workslices/models.py
+++ b/linz2osm/workslices/models.py
@@ -147,6 +147,7 @@ class Workslice(models.Model):
     followup_deadline = models.DateTimeField(null=True, blank=True)
     user = models.ForeignKey(auth.models.User)
     layer_in_dataset = models.ForeignKey(LayerInDataset)
+    version = models.TextField(blank=True)
     checkout_extent = models.MultiPolygonField()
     feature_count = models.IntegerField(null=True)
     file_size = models.IntegerField(null=True)

--- a/linz2osm/workslices/models.py
+++ b/linz2osm/workslices/models.py
@@ -315,6 +315,14 @@ class WorksliceFeature(models.Model):
                 %(bounds)s;
                 >;
                 );""")
+        elif geotype == "RELATION":
+            query = dedent("""
+                (
+                rel
+                %(tags)s
+                %(bounds)s;
+                >;
+                );""")
         else:
             raise ValueError("Unsupported geometry type %s" % geotype)
 

--- a/linz2osm/workslices/views.py
+++ b/linz2osm/workslices/views.py
@@ -275,6 +275,10 @@ def workslice_info(request, layer_in_dataset_id):
                         conflict_count = len(ways) # FIXME: count rels too.
                         if form.cleaned_data['show_conflicting_features'] == 'yes':
                             ctx['osm_conflict_geometry'] = overpass.osm_geojson(rels.values(), nodes, ways)
+                    elif layer.geometry_type == 'RELATION':
+                        conflict_count = len(rels)
+                        if form.cleaned_data['show_conflicting_features'] == 'yes':
+                            ctx['osm_conflict_geometry'] = overpass.osm_geojson(rels.values(), nodes, ways)
 
                     if conflict_count > 1:
                         ctx['osm_conflict_info'] = "%d nearby features of this type in OSM." % conflict_count

--- a/scripts/mp2postgis.py
+++ b/scripts/mp2postgis.py
@@ -299,9 +299,9 @@ class MPRestrict(MPRecord):
         ("node_id_2", "integer"), # REFERENCES mp_node(id)
         ("node_id_3", "integer"), # REFERENCES mp_node(id)
         ("node_id_4", "integer"), # REFERENCES mp_node(id)
-        ("road_id_1", "integer"),
-        ("road_id_2", "integer"),
-        ("road_id_3", "integer"),
+        ("road_id_1", VARCHAR),
+        ("road_id_2", VARCHAR),
+        ("road_id_3", VARCHAR),
         ("not_for_emergency", FLAG_DEF_FALSE),
         ("not_for_goods", FLAG_DEF_FALSE),
         ("not_for_car", FLAG_DEF_FALSE),


### PR DESCRIPTION
https://github.com/opennewzealand/linz2osm/issues/115

Current status: 
- have made model changes to LINZ2OSM to support layers that are a "relation" containing other layers
- model changes to track versioned data
- have done some uploads of NZOpenGPS data so that I can test API queries needed for export
- in the middle of updating NZOpenGPS parser to include some extra info I'll need (geometries for nodes, as well as road segments).
- updated workslice map to get geometries from join table for "relation" layers
- export support for relations
- configured tagging for turn restriction layer (on dev)
- specify whether turn prohibited is left, right etc.
- copy tagging onto production
- overpass API query to get existing node and way IDs within export
- updated versions of NZOpenGPS data on production (already tested this process for Wellington).
